### PR TITLE
Update AirtableApiClient.Tests.csproj

### DIFF
--- a/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
+++ b/AirtableApiClient.Tests/AirtableApiClient.Tests.csproj
@@ -40,7 +40,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AirtableApiClient, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Airtable.1.1.5\lib\netstandard2.0\AirtableApiClient.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\AirtableApiClient\bin\Debug\AirtableApiClient.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>


### PR DESCRIPTION
Renamed tests so that they can run in the desired order in VS2019 MSTest.